### PR TITLE
set a default value for ES url, such that it automatically uses this …

### DIFF
--- a/openshift/ad_demo.yaml
+++ b/openshift/ad_demo.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Template
 labels:
@@ -101,5 +102,5 @@ parameters:
     required: true
   - name: ELASTICSEARCH_URL
     displayName: Host URL for elasticsearch
+    value: http://$(LAD_ELASTICSEARCH_SERVICE_SERVICE_HOST):$(LAD_ELASTICSEARCH_SERVICE_SERVICE_PORT)
     required: false
-


### PR DESCRIPTION
…service https://github.com/4n4nd/log-anomaly-detector/blob/master/openshift/lad-elasticsearch-deployment.yaml#L56